### PR TITLE
fix(codecov): remove patch

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,6 +5,7 @@ coverage:
   range: "30...100"
   precision: 1
   status:
+    patch: off
     project:
       default:
         target: 30%


### PR DESCRIPTION
Linked to none issue.

### Description

Related to [Codecov Status check](https://docs.codecov.com/docs/commit-status):

"The `codecov/patch` status only measures lines adjusted in the pull request or single commit, if the commit is not in a pull request. This status provides an indication on how well the pull request is tested."

In other words, it will not compare code to base code (in most cases, main). It can be usefull when we want a project full clean with many many tests, but for this project, we don't think that tests should be our priority.