### PR TITLE
feat: add WebView to mobile

### DIFF
--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -90,6 +90,19 @@ android {
             keyPassword 'azerqsdf'
         }
     }
+    lintOptions {
+        checkReleaseBuilds false
+        // ... (other lint options)
+
+        // Add the following lines to declare dependencies
+        abortOnError false
+        checkDependencies false
+    }
+    applicationVariants.all { variant ->
+        if (variant.buildType.name == 'debug') {
+            variant.preBuild.dependsOn 'copyReactNativeVectorIconFonts'
+        }
+    }
     buildTypes {
         debug {
             signingConfig signingConfigs.debug
@@ -106,6 +119,7 @@ android {
 
 dependencies {
     // The version of react-native is set by the React Native Gradle Plugin
+    implementation project(':react-native-webview')
     implementation("com.facebook.react:react-android")
     implementation("com.facebook.react:flipper-integration")
 

--- a/mobile/android/app/src/main/java/com/areamobile/MainApplication.kt
+++ b/mobile/android/app/src/main/java/com/areamobile/MainApplication.kt
@@ -5,6 +5,7 @@ import com.facebook.react.PackageList
 import com.facebook.react.ReactApplication
 import com.facebook.react.ReactHost
 import com.facebook.react.ReactNativeHost
+import com.reactnativecommunity.webview.RNCWebViewPackage;
 import com.facebook.react.ReactPackage
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.load
 import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost

--- a/mobile/android/build.gradle
+++ b/mobile/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         buildToolsVersion = "34.0.0"
-        minSdkVersion = 21
+        minSdkVersion = 23
         compileSdkVersion = 34
         targetSdkVersion = 34
         ndkVersion = "25.1.8937393"

--- a/mobile/android/settings.gradle
+++ b/mobile/android/settings.gradle
@@ -1,4 +1,6 @@
 rootProject.name = 'mobile'
 apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
+include ':react-native-webview'
+project(':react-native-webview').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-webview/android')
 include ':app'
 includeBuild('../node_modules/@react-native/gradle-plugin')

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -23,6 +23,7 @@
     "react-native-paper": "^5.11.4",
     "react-native-safe-area-context": "^4.8.2",
     "react-native-screens": "^3.29.0",
+    "react-native-webview": "^13.6.4",
     "react-navigation": "^5.0.0",
     "react-router-native": "^6.21.0"
   },


### PR DESCRIPTION
to add this component to a view, make something like this: 
```React
import React, { Component } from 'react';
import { StyleSheet, Text, View } from 'react-native';
import { WebView } from 'react-native-webview';

// ...
const MyWebComponent = () => {
  return <WebView source={{ uri: 'http://10.0.2.2:8081/Services/' }} style={{ flex: 1 }} />;
}
```
the url http://10.0.2.2:8081/Services/ is just a example, it is just to check that it work.
When it work with this route, we gonna try with http://10.0.2.2:8081/ServicesConnexion

If you really want to test if it work, test with a existing url, like https://en.wikipedia.org/wiki/Simple_view_of_reading